### PR TITLE
feat(plugin): parse link attrs itself

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@diplodoc/utils": "^2.0.1"
+        "@diplodoc/utils": "^2.1.0"
       },
       "devDependencies": {
         "@diplodoc/lint": "^1.2.0",
@@ -625,11 +625,12 @@
       "dev": true
     },
     "node_modules/@diplodoc/utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@diplodoc/utils/-/utils-2.0.1.tgz",
-      "integrity": "sha512-BmEpoWG2fzaBlbS0l7o/nYc4Ww9QXeQGzHM6fTFk6gPV0PRl55aBxMx+60VZn7rDhiKwAQX97yTElBzoznTt4g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@diplodoc/utils/-/utils-2.1.0.tgz",
+      "integrity": "sha512-1XfZSb0gPLqSRGwxlLHcXo4c59bcFomcEaDM5v2S/aFDhgNRfZgDGxWEbHwkIijfBB2rvFWuVgKzON0VDp2uqQ==",
+      "license": "MIT",
       "peerDependencies": {
-        "react": "^16.8.0  || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0  || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "react": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@diplodoc/utils": "^2.0.1"
+    "@diplodoc/utils": "^2.1.0"
   },
   "devDependencies": {
     "@diplodoc/lint": "^1.2.0",

--- a/src/plugin/const.ts
+++ b/src/plugin/const.ts
@@ -9,3 +9,5 @@ export const TokenType = {
 export const ClassNames = {
     QuoteLink: 'yfm-quote-link',
 } as const;
+
+export const QUOTE_LINK_ATTR = 'data-quotelink';

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -6,9 +6,6 @@
   "packages": {
     "": {
       "name": "@diplodoc/tests",
-      "dependencies": {
-        "markdown-it-attrs": "^4.3.1"
-      },
       "devDependencies": {
         "@diplodoc/transform": "^4.45.2",
         "@types/jest": "^29.5.12",
@@ -1835,7 +1832,8 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/arr-diff": {
       "version": "4.0.0",
@@ -4986,6 +4984,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
       "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
+      "dev": true,
       "dependencies": {
         "uc.micro": "^1.0.1"
       }
@@ -5080,6 +5079,7 @@
       "version": "13.0.2",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.2.tgz",
       "integrity": "sha512-FtwnEuuK+2yVU7goGn/MJ0WBZMM9ZPgU9spqlFs7/A/pDIUNSOQZhUgOqYCficIuR2QaFnrt8LHqBWsbTAoI5w==",
+      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "~3.0.1",
@@ -5095,6 +5095,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-4.3.1.tgz",
       "integrity": "sha512-/ko6cba+H6gdZ0DOw7BbNMZtfuJTRp9g/IrGIuz8lYc/EfnmWRpaR3CFPnNbVz0LDvF8Gf1hFGPqrQqq7De0rg==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       },
@@ -5159,6 +5160,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
       "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "dev": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -5209,7 +5211,8 @@
     "node_modules/mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "dev": true
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -7108,7 +7111,8 @@
     "node_modules/uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "dev": true
     },
     "node_modules/undici": {
       "version": "6.19.8",

--- a/tests/package.json
+++ b/tests/package.json
@@ -16,8 +16,5 @@
     "jest-serializer-html": "^7.1.0",
     "ts-dedent": "^2.2.0",
     "typescript": "^5.5.4"
-  },
-  "dependencies": {
-    "markdown-it-attrs": "^4.3.1"
   }
 }

--- a/tests/src/plugin.test.ts
+++ b/tests/src/plugin.test.ts
@@ -1,13 +1,16 @@
 import transform from '@diplodoc/transform';
 import dd from 'ts-dedent';
 import MarkdownIt from 'markdown-it';
-import attrs from 'markdown-it-attrs';
 
 import * as quoteLinkExtension from '../../src/plugin';
 
 const html = (text: string, opts?: quoteLinkExtension.TransformOptions) => {
     const {result} = transform(text, {
-        plugins: [quoteLinkExtension.transform({bundle: false, ...opts})],
+        plugins: [
+            quoteLinkExtension.transform({bundle: false, ...opts}),
+            // disable markdown-it-attrs
+            (md) => md.core.ruler.disable('curly_attributes'),
+        ],
     });
 
     return result.html;
@@ -23,7 +26,6 @@ const meta = (text: string, opts?: quoteLinkExtension.TransformOptions) => {
 
 const parse = (text: string, opts?: quoteLinkExtension.TransformOptions) => {
     const md = new MarkdownIt().use(quoteLinkExtension.transform({bundle: false, ...opts}));
-    md.use(attrs, {leftDelimiter: '{', rightDelimiter: '}'});
     return md.parse(text, {});
 };
 


### PR DESCRIPTION
Removed implicit dependency on `markdown-it-attrs`: the plugin itself parses attributes for the link

This is the part of deprecating `markdown-it-attrs` in diplodoc platform, see diplodoc-platform/diplodoc#45