### PR TITLE
fix: exclude build:clean from the parallel build glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build"
   ],
   "scripts": {
-    "build": "npm run build:clean && run-p build:*",
+    "build": "npm run build:clean && run-p build:js build:declarations",
     "build:clean": "node scripts/clean.mjs",
     "build:js": "node esbuild/build.mjs",
     "build:declarations": "tsc -p tsconfig.publish.json --emitDeclarationOnly --outDir ./build",


### PR DESCRIPTION
## Problem

`"build": "npm run build:clean && run-p build:*"` - the `build:*` glob also matches `build:clean`, so after the initial sequential clean, `run-p` launches it again in parallel with `build:js` and `build:declarations`. The second clean races with esbuild/tsc writing into `build/` and can delete freshly written artifacts while the build still exits 0, producing a package with missing files.

Same class of bug as diplodoc-platform/page-constructor-extension#92, where this race intermittently broke the diplodoc metarepo E2E.

## Fix

List the build steps explicitly so clean runs exactly once, before them:

```
"build": "npm run build:clean && run-p build:js build:declarations"
```